### PR TITLE
Add event callback mechanism to ISD04 driver

### DIFF
--- a/src/isd04_driver.c
+++ b/src/isd04_driver.c
@@ -1,4 +1,5 @@
 #include "isd04_driver.h"
+#include <stddef.h>
 
 /** Clamp speed to the allowable range. */
 static int32_t clamp_speed(const Isd04Driver *driver, int32_t speed);
@@ -12,6 +13,8 @@ void isd04_driver_init(Isd04Driver *driver, const Isd04Config *config)
     driver->config = *config;
     driver->current_speed = 0;
     driver->running = false;
+    driver->callback = NULL;
+    driver->callback_context = NULL;
 }
 
 void isd04_driver_start(Isd04Driver *driver)
@@ -21,6 +24,9 @@ void isd04_driver_start(Isd04Driver *driver)
     }
 
     driver->running = true;
+    if (driver->callback) {
+        driver->callback(ISD04_EVENT_STARTED, driver->callback_context);
+    }
 }
 
 void isd04_driver_stop(Isd04Driver *driver)
@@ -31,6 +37,9 @@ void isd04_driver_stop(Isd04Driver *driver)
 
     driver->running = false;
     driver->current_speed = 0;
+    if (driver->callback) {
+        driver->callback(ISD04_EVENT_STOPPED, driver->callback_context);
+    }
 }
 
 void isd04_driver_set_speed(Isd04Driver *driver, int32_t speed)
@@ -38,8 +47,23 @@ void isd04_driver_set_speed(Isd04Driver *driver, int32_t speed)
     if (!driver) {
         return;
     }
+    int32_t new_speed = clamp_speed(driver, speed);
+    if (new_speed != driver->current_speed) {
+        driver->current_speed = new_speed;
+        if (driver->callback) {
+            driver->callback(ISD04_EVENT_SPEED_CHANGED, driver->callback_context);
+        }
+    }
+}
 
-    driver->current_speed = clamp_speed(driver, speed);
+void isd04_driver_register_callback(Isd04Driver *driver, Isd04EventCallback callback, void *context)
+{
+    if (!driver) {
+        return;
+    }
+
+    driver->callback = callback;
+    driver->callback_context = context;
 }
 
 static int32_t clamp_speed(const Isd04Driver *driver, int32_t speed)

--- a/src/isd04_driver.h
+++ b/src/isd04_driver.h
@@ -19,6 +19,21 @@ typedef struct {
 } Isd04Config;
 
 /**
+ * Events that can be emitted by the driver.
+ */
+typedef enum {
+    /** Motor has started running. */
+    ISD04_EVENT_STARTED,
+    /** Motor has stopped running. */
+    ISD04_EVENT_STOPPED,
+    /** Motor speed has been updated. */
+    ISD04_EVENT_SPEED_CHANGED,
+} Isd04Event;
+
+/** Callback invoked when a driver event occurs. */
+typedef void (*Isd04EventCallback)(Isd04Event event, void *context);
+
+/**
  * Runtime state for an ISD04 motor driver instance.
  */
 typedef struct {
@@ -28,12 +43,17 @@ typedef struct {
     int32_t current_speed;
     /** Indicates whether the motor is running. */
     bool running;
+    /** Registered event callback. */
+    Isd04EventCallback callback;
+    /** User supplied context passed to the callback. */
+    void *callback_context;
 } Isd04Driver;
 
 void isd04_driver_init(Isd04Driver *driver, const Isd04Config *config);
 void isd04_driver_start(Isd04Driver *driver);
 void isd04_driver_stop(Isd04Driver *driver);
 void isd04_driver_set_speed(Isd04Driver *driver, int32_t speed);
+void isd04_driver_register_callback(Isd04Driver *driver, Isd04EventCallback callback, void *context);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- add Isd04Event enum and callback typedef
- add callback registration to store function and context
- trigger callbacks on driver state changes

## Testing
- `gcc -std=c99 -Wall -Wextra -c src/isd04_driver.c -o /tmp/isd04_driver.o`


------
https://chatgpt.com/codex/tasks/task_e_68a152d8898c83239508b0b1abe40408