### PR TITLE
Add singleton accessor for ISD04 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # isd04-motor-driver
 Portable C driver for the ISD04 motor driver IC with STM32 HAL reference port, example projects, and Python-based telemetry visualization.
+
+## Usage
+
+```c
+#include "isd04_driver.h"
+
+int main(void) {
+    Isd04Config config = {
+        .pwm_frequency_hz = 1000,
+        .max_speed = 100,
+    };
+
+    Isd04Driver *driver = isd04_driver_get_instance();
+    isd04_driver_init(driver, &config);
+    isd04_driver_start(driver);
+
+    /* ... */
+
+    isd04_driver_stop(driver);
+    return 0;
+}
+```

--- a/src/isd04_driver.c
+++ b/src/isd04_driver.c
@@ -1,8 +1,22 @@
 #include "isd04_driver.h"
 #include <stddef.h>
+#include <stdlib.h>
+
+/** Singleton driver instance. */
+static Isd04Driver *instance = NULL;
 
 /** Clamp speed to the allowable range. */
 static int32_t clamp_speed(const Isd04Driver *driver, int32_t speed);
+
+Isd04Driver *isd04_driver_get_instance(void)
+{
+    if (instance) {
+        return instance;
+    }
+
+    instance = calloc(1, sizeof(Isd04Driver));
+    return instance;
+}
 
 void isd04_driver_init(Isd04Driver *driver, const Isd04Config *config)
 {

--- a/src/isd04_driver.h
+++ b/src/isd04_driver.h
@@ -54,6 +54,7 @@ void isd04_driver_start(Isd04Driver *driver);
 void isd04_driver_stop(Isd04Driver *driver);
 void isd04_driver_set_speed(Isd04Driver *driver, int32_t speed);
 void isd04_driver_register_callback(Isd04Driver *driver, Isd04EventCallback callback, void *context);
+Isd04Driver *isd04_driver_get_instance(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- add static singleton instance for ISD04 driver
- expose `isd04_driver_get_instance` to lazily allocate and return the driver
- document new usage pattern in README

## Testing
- `gcc -std=c99 -Wall -Wextra -pedantic -c src/isd04_driver.c`


------
https://chatgpt.com/codex/tasks/task_e_68a153adc8dc8323856c9a6f07e6cb23