### PR TITLE
Track motor position in ISD04 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ int main(void) {
     isd04_driver_start(driver);
     isd04_driver_set_speed(driver, 50);
 
-    /* query current behavioral state */
-    Isd04StateId state = isd04_driver_get_state(driver);
-    (void)state;
+    /* periodically advance position and read it */
+    isd04_driver_step(driver, 1); /* call from a timer/interrupt */
+    int32_t pos = isd04_driver_get_position(driver);
+    (void)pos;
 
     /* ... */
 
@@ -39,3 +40,7 @@ int main(void) {
     return 0;
 }
 ```
+
+To keep the driver's `current_position` in sync with actual motor motion, call
+`isd04_driver_step` from a periodic timer or interrupt whenever step pulses are
+issued. This allows real-time position queries via `isd04_driver_get_position`.

--- a/src/isd04_driver.c
+++ b/src/isd04_driver.c
@@ -138,6 +138,7 @@ void isd04_driver_init(Isd04Driver *driver, const Isd04Config *config)
 
     driver->config = *config;
     driver->current_speed = 0;
+    driver->current_position = 0;
     driver->running = false;
     driver->callback = NULL;
     driver->callback_context = NULL;
@@ -213,6 +214,38 @@ Isd04StateId isd04_driver_get_state(const Isd04Driver *driver)
         return ISD04_STATE_STOPPED;
     }
     return driver->state->id;
+}
+
+int32_t isd04_driver_get_position(const Isd04Driver *driver)
+{
+    if (!driver) {
+        return 0;
+    }
+    return driver->current_position;
+}
+
+void isd04_driver_set_position(Isd04Driver *driver, int32_t position)
+{
+    if (!driver) {
+        return;
+    }
+    if (driver->current_position != position) {
+        driver->current_position = position;
+        if (driver->callback) {
+            driver->callback(ISD04_EVENT_POSITION_CHANGED, driver->callback_context);
+        }
+    }
+}
+
+void isd04_driver_step(Isd04Driver *driver, int32_t steps)
+{
+    if (!driver || steps == 0) {
+        return;
+    }
+    driver->current_position += steps;
+    if (driver->callback) {
+        driver->callback(ISD04_EVENT_POSITION_CHANGED, driver->callback_context);
+    }
 }
 
 static int32_t clamp_speed(const Isd04Driver *driver, int32_t speed)

--- a/src/isd04_driver.h
+++ b/src/isd04_driver.h
@@ -30,6 +30,8 @@ typedef enum {
     ISD04_EVENT_SPEED_CHANGED,
     /** Microstep resolution has changed. */
     ISD04_EVENT_MICROSTEP_CHANGED,
+    /** Motor position has changed. */
+    ISD04_EVENT_POSITION_CHANGED,
 } Isd04Event;
 
 /** Supported microstep resolutions. */
@@ -81,6 +83,8 @@ typedef struct {
     Isd04Config config;
     /** Current motor speed. */
     int32_t current_speed;
+    /** Current motor position in steps. */
+    int32_t current_position;
     /** Indicates whether the motor is running. */
     bool running;
     /** Registered event callback. */
@@ -102,6 +106,27 @@ Isd04Microstep isd04_driver_get_microstep(const Isd04Driver *driver);
 void isd04_driver_register_callback(Isd04Driver *driver, Isd04EventCallback callback, void *context);
 Isd04Driver *isd04_driver_get_instance(void);
 Isd04StateId isd04_driver_get_state(const Isd04Driver *driver);
+
+/**
+ * Retrieve the driver's notion of the current motor position in steps.
+ */
+int32_t isd04_driver_get_position(const Isd04Driver *driver);
+
+/**
+ * Set the driver's current motor position counter.
+ *
+ * Emits ::ISD04_EVENT_POSITION_CHANGED if the value differs.
+ */
+void isd04_driver_set_position(Isd04Driver *driver, int32_t position);
+
+/**
+ * Advance the driver's internal position counter.
+ *
+ * Call this periodically (e.g., from a timer interrupt) with the number of
+ * steps that have been issued to the motor since the last call to keep the
+ * position in sync with actual movement.
+ */
+void isd04_driver_step(Isd04Driver *driver, int32_t steps);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- add `current_position` field and new `ISD04_EVENT_POSITION_CHANGED`
- provide `isd04_driver_get/set_position` and `isd04_driver_step`
- document periodic stepping and example position reads in README

## Testing
- `gcc -std=c99 -c src/isd04_driver.c -Wall`

------
https://chatgpt.com/codex/tasks/task_e_68a15ee2807483239212de8b944d354b