### PR TITLE
Add driver version query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Portable C driver for the ISD04 motor driver IC with STM32 HAL reference port, example projects, and Python-based telemetry visualization.
 
 ## Usage
+Call `isd04_driver_get_version()` to retrieve the driver's version string.
 
 ```c
 #include "isd04_driver.h"
@@ -24,6 +25,9 @@ static void on_event(Isd04Event event, void *context) {
 }
 
 int main(void) {
+    const char *version = isd04_driver_get_version();
+    (void)version;
+
     Isd04Config config;
     isd04_driver_get_default_config(&config);
 

--- a/src/isd04_driver.c
+++ b/src/isd04_driver.c
@@ -10,6 +10,11 @@ static int32_t clamp_speed(const Isd04Driver *driver, int32_t speed);
 /** Clamp microstep mode to the allowable range. */
 static Isd04Microstep clamp_microstep(Isd04Microstep mode);
 
+const char *isd04_driver_get_version(void)
+{
+    return ISD04_DRIVER_VERSION_STRING;
+}
+
 /** State object defining behaviour for driver operations. */
 typedef struct Isd04State {
     Isd04StateId id;

--- a/src/isd04_driver.h
+++ b/src/isd04_driver.h
@@ -14,6 +14,11 @@ static inline void HAL_GPIO_WritePin(GPIO_TypeDef *port, uint16_t pin, GPIO_PinS
 }
 #endif
 
+#define ISD04_DRIVER_VERSION_MAJOR 1
+#define ISD04_DRIVER_VERSION_MINOR 0
+#define ISD04_DRIVER_VERSION_PATCH 0
+#define ISD04_DRIVER_VERSION_STRING "1.0.0"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -133,6 +138,7 @@ typedef struct {
     const struct Isd04State *state;
 } Isd04Driver;
 
+const char *isd04_driver_get_version(void);
 void isd04_driver_get_default_config(Isd04Config *config);
 void isd04_driver_init(Isd04Driver *driver, const Isd04Config *config, const Isd04Hardware *hw);
 void isd04_driver_start(Isd04Driver *driver);


### PR DESCRIPTION
## Summary
- define driver version macros and accessor
- expose API to retrieve ISD04 driver version
- document version retrieval in README usage example

## Testing
- `gcc -c src/isd04_driver.c -std=c99`


------
https://chatgpt.com/codex/tasks/task_e_68a169d9f7d88323801923d84754d132