### PR TITLE
Add GPIO error handling and wrapper in ISD04 driver

### DIFF
--- a/src/isd04_driver.h
+++ b/src/isd04_driver.h
@@ -70,6 +70,8 @@ typedef enum {
     ISD04_EVENT_MICROSTEP_CHANGED,
     /** Motor position has changed. */
     ISD04_EVENT_POSITION_CHANGED,
+    /** A hardware access failure occurred. */
+    ISD04_EVENT_ERROR,
 } Isd04Event;
 
 /** DIP switch patterns for microstep modes. */
@@ -101,6 +103,7 @@ typedef enum {
  * - ::ISD04_EVENT_SPEED_CHANGED when the commanded speed is updated.
  * - ::ISD04_EVENT_MICROSTEP_CHANGED after a new microstepping mode is applied.
  * - ::ISD04_EVENT_POSITION_CHANGED whenever the tracked position is modified.
+ * - ::ISD04_EVENT_ERROR if a hardware write operation fails.
  */
 typedef void (*Isd04EventCallback)(Isd04Event event, void *context);
 
@@ -136,6 +139,8 @@ typedef struct {
     Isd04Microstep microstep;
     /** Current behavioral state of the driver. */
     const struct Isd04State *state;
+    /** Set when a hardware error has been detected. */
+    bool error;
 } Isd04Driver;
 
 const char *isd04_driver_get_version(void);


### PR DESCRIPTION
## Summary
- Wrap HAL_GPIO_WritePin with `isd04_gpio_write_pin` to report failures
- Validate hardware pin configuration during driver init
- Propagate GPIO write errors via callback and internal flag
- Document new `ISD04_EVENT_ERROR` event in API

## Testing
- `gcc -c src/isd04_driver.c -std=c99`


------
https://chatgpt.com/codex/tasks/task_e_68a16b39fe84832394b2c64daf60e4e1