### PR TITLE
Add delay helper macros for ISD04 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,20 @@ int main(void) {
 `isd04_driver_pulse` toggles the step pin and updates the driver's internal
 position counter. If step pulses are produced elsewhere, call
 `isd04_driver_step` to keep the tracked position synchronized.
+
+## Timing helpers
+
+The driver exposes a small set of macros for integrating with platform-specific
+delay mechanisms:
+
+* `ISD04_DELAY_MS(ms)` – delay for a number of milliseconds.  Expands to
+  `HAL_Delay` when `USE_HAL_DRIVER` is defined, to `osDelay` when
+  `CMSIS_OS_VERSION` is defined, and otherwise becomes a no-op.
+* `ISD04_DELAY_START()` / `ISD04_DELAY_ELAPSED(start, ms)` – capture a tick
+  count and test whether a duration has passed.  These map to `HAL_GetTick` or
+  `osKernelSysTick` depending on the same compile-time symbols.
+
+Define `USE_HAL_DRIVER` to build against the STM32 HAL and `CMSIS_OS_VERSION`
+when a CMSIS-RTOS is present.  Projects may also set
+`ISD04_STEP_PULSE_DELAY_MS` to a non-zero value to enforce a minimum step pulse
+width using the delay helpers.

--- a/src/isd04_driver.c
+++ b/src/isd04_driver.c
@@ -5,6 +5,13 @@
 /** Singleton driver instance. */
 static Isd04Driver *instance = NULL;
 
+/* Optional delay between rising and falling edges of the step pulse in
+ * milliseconds.  Projects can override this at compile time to ensure the
+ * pulse meets the driver's minimum width requirements. */
+#ifndef ISD04_STEP_PULSE_DELAY_MS
+#define ISD04_STEP_PULSE_DELAY_MS 0U
+#endif
+
 /**
  * Wrapper around HAL_GPIO_WritePin that returns success/failure.
  *
@@ -286,6 +293,10 @@ void isd04_driver_pulse(Isd04Driver *driver)
         }
         return;
     }
+#if ISD04_STEP_PULSE_DELAY_MS > 0U
+    /* Ensure minimum pulse width using the delay helpers. */
+    ISD04_DELAY_MS(ISD04_STEP_PULSE_DELAY_MS);
+#endif
     if (!isd04_gpio_write_pin(driver->hw.stp_port, driver->hw.stp_pin, GPIO_PIN_RESET)) {
         driver->error = true;
         if (driver->callback) {

--- a/src/isd04_driver.h
+++ b/src/isd04_driver.h
@@ -14,6 +14,39 @@ static inline void HAL_GPIO_WritePin(GPIO_TypeDef *port, uint16_t pin, GPIO_PinS
 }
 #endif
 
+/**
+ * Delay helper macros.
+ *
+ * Depending on the build environment these expand to the appropriate HAL or
+ * CMSIS-RTOS primitives.  When neither `USE_HAL_DRIVER` nor `CMSIS_OS_VERSION`
+ * is defined they fall back to no-ops which allows the driver to be built for
+ * host side tests.
+ */
+#ifdef CMSIS_OS_VERSION
+#include "cmsis_os.h"
+/** Delay for the specified number of milliseconds. */
+#define ISD04_DELAY_MS(ms)            osDelay(ms)
+typedef uint32_t Isd04DelayTick;
+/** Capture the current system tick for later elapsed checks. */
+#define ISD04_DELAY_START()           (osKernelSysTick())
+/** Check whether @p ms milliseconds have elapsed since @p start. */
+#define ISD04_DELAY_ELAPSED(start, ms) ((uint32_t)(osKernelSysTick() - (start)) >= (ms))
+#elif defined(USE_HAL_DRIVER)
+/** Delay for the specified number of milliseconds using the HAL. */
+#define ISD04_DELAY_MS(ms)            HAL_Delay(ms)
+typedef uint32_t Isd04DelayTick;
+/** Capture the current HAL tick for later elapsed checks. */
+#define ISD04_DELAY_START()           (HAL_GetTick())
+/** Check whether @p ms milliseconds have elapsed since @p start. */
+#define ISD04_DELAY_ELAPSED(start, ms) ((uint32_t)(HAL_GetTick() - (start)) >= (ms))
+#else
+/** No-op delay used when neither HAL nor CMSIS-RTOS is available. */
+#define ISD04_DELAY_MS(ms)            do { (void)(ms); } while (0)
+typedef uint32_t Isd04DelayTick;
+#define ISD04_DELAY_START()           (0U)
+#define ISD04_DELAY_ELAPSED(start, ms) ((void)(start), (void)(ms), true)
+#endif
+
 #define ISD04_DRIVER_VERSION_MAJOR 1
 #define ISD04_DRIVER_VERSION_MINOR 0
 #define ISD04_DRIVER_VERSION_PATCH 0


### PR DESCRIPTION
## Summary
- add portable delay helper macros for HAL and CMSIS-RTOS
- allow optional step pulse width delay using the helpers
- document delay macros and related build symbols

## Testing
- `gcc -std=c99 -c src/isd04_driver.c`

------
https://chatgpt.com/codex/tasks/task_e_68a16e441aa88323a91ba38092f9aa17