### PR TITLE
Add GPIO pin validation and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ int main(void) {
 }
 ```
 
+The driver validates that the provided GPIO pins fall within the target MCU's
+pin count.  Override `ISD04_GPIO_PIN_COUNT` at compile time if your platform
+exposes a different number of pins per port.  Applications may use the
+`ISD04_VALIDATE_PIN(pin)` macro for their own static assertions.
+
 `isd04_driver_pulse` toggles the step pin and updates the driver's internal
 position counter. If step pulses are produced elsewhere, call
 `isd04_driver_step` to keep the tracked position synchronized.
@@ -81,3 +86,7 @@ Define `USE_HAL_DRIVER` to build against the STM32 HAL and `CMSIS_OS_VERSION`
 when a CMSIS-RTOS is present.  Projects may also set
 `ISD04_STEP_PULSE_DELAY_MS` to a non-zero value to enforce a minimum step pulse
 width using the delay helpers.
+
+## Version history
+
+* **1.0.1** – Added pin range validation and `ISD04_VALIDATE_PIN` macro.

--- a/src/isd04_driver.c
+++ b/src/isd04_driver.c
@@ -183,6 +183,13 @@ void isd04_driver_init(Isd04Driver *driver, const Isd04Config *config, const Isd
         return;
     }
 
+    if (!ISD04_VALIDATE_PIN(hw->stp_pin) ||
+        !ISD04_VALIDATE_PIN(hw->dir_pin) ||
+        !ISD04_VALIDATE_PIN(hw->ena_pin)) {
+        driver->error = true;
+        return;
+    }
+
     driver->config = *config;
     driver->hw = *hw;
     driver->current_speed = 0;


### PR DESCRIPTION
## Summary
- add `ISD04_VALIDATE_PIN` macro and GPIO pin count constant
- validate hardware pin numbers in `isd04_driver_init`
- document pin validation and bump version to 1.0.1

## Testing
- `gcc -Wall -Werror -c src/isd04_driver.c -o /tmp/isd04_driver.o && ls -l /tmp/isd04_driver.o`


------
https://chatgpt.com/codex/tasks/task_e_68a1cf727e50832397a2d61a5a8c9a87