### PR TITLE
Track enable state and pulse timing in ISD04 driver

### DIFF
--- a/src/isd04_driver.h
+++ b/src/isd04_driver.h
@@ -200,6 +200,10 @@ typedef struct {
     int32_t current_position;
     /** Indicates whether the motor is running. */
     bool running;
+    /** Set when the driver outputs are enabled. */
+    bool enabled;
+    /** Tick recorded when the last step pulse was issued. */
+    Isd04DelayTick last_step_tick;
     /** Registered event callback. */
     Isd04EventCallback callback;
     /** User supplied context passed to the callback. */


### PR DESCRIPTION
## Summary
- Track whether outputs are enabled and last pulse tick in `Isd04Driver`
- Delay after enabling driver to satisfy wake requirements
- Enforce minimum spacing between step pulses and record pulse time

## Testing
- `gcc -std=c11 -Wall -Werror -c src/isd04_driver.c`

------
https://chatgpt.com/codex/tasks/task_e_68a1f880b4448323a1623de6e99dc9da