### PR TITLE
Add configurable ENA pin polarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ All three logic inputs default high when left floating. Drive STEP high then
 low to advance a microstep, set DIR high for forward rotation and low for
 reverse, and pull ENA low to enable the outputs (high disables the driver).
 
+The disable polarity of the ENA pin is controlled by the `ISD04_ENA_ACTIVE_LEVEL`
+macro. By default it assumes an active-low disable (`GPIO_PIN_RESET`); define it
+as `GPIO_PIN_SET` if your hardware disables the driver with a high level.
+
 ## Usage
 
 ```c

--- a/src/isd04_driver.c
+++ b/src/isd04_driver.c
@@ -282,8 +282,10 @@ void isd04_driver_enable(Isd04Driver *driver, bool enable)
         return;
     }
     bool was_enabled = driver->enabled;
-    if (!isd04_gpio_write_pin(driver->hw.ena_port, driver->hw.ena_pin,
-                               enable ? GPIO_PIN_SET : GPIO_PIN_RESET)) {
+    GPIO_PinState level = enable
+        ? (ISD04_ENA_ACTIVE_LEVEL == GPIO_PIN_SET ? GPIO_PIN_RESET : GPIO_PIN_SET)
+        : ISD04_ENA_ACTIVE_LEVEL;
+    if (!isd04_gpio_write_pin(driver->hw.ena_port, driver->hw.ena_pin, level)) {
         driver->error = true;
         if (driver->callback) {
             driver->callback(ISD04_EVENT_ERROR, driver->callback_context);

--- a/src/isd04_driver.h
+++ b/src/isd04_driver.h
@@ -57,6 +57,10 @@ typedef uint32_t Isd04DelayTick;
 #define ISD04_ENABLE_WAKE_DELAY_MS 1U  /* delay after enabling driver */
 #endif
 
+#ifndef ISD04_ENA_ACTIVE_LEVEL
+#define ISD04_ENA_ACTIVE_LEVEL GPIO_PIN_RESET  /* active-low disable */
+#endif
+
 #define ISD04_DRIVER_VERSION_MAJOR 1
 #define ISD04_DRIVER_VERSION_MINOR 0
 #define ISD04_DRIVER_VERSION_PATCH 1


### PR DESCRIPTION
## Summary
- Add `ISD04_ENA_ACTIVE_LEVEL` macro to configure enable-pin disable polarity
- Use macro in `isd04_driver_enable` instead of hard-coded GPIO levels
- Document enable polarity override in README

## Testing
- `gcc -std=c11 -Wall -Wextra -Isrc -c src/isd04_driver.c -o /tmp/isd04_driver.o`


------
https://chatgpt.com/codex/tasks/task_e_68a1f9ccba0883239be87792183c0e68