### PR TITLE
Add GPIO and timer usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ Key options include:
 - `ISD04_ENABLE_WAKE_DELAY_MS`: driver wake-up delay (default: 1ms)
 - `ISD04_GPIO_PIN_COUNT`: GPIO pin validation range (default: 16)
 
+## Examples
+
+Two reference applications are provided in the `examples` directory:
+
+- `examples/main_gpio.c` demonstrates manual STEP pulses via GPIO (ISD04_STEP_CONTROL_TIMER=0).
+- `examples/main_timer.c` drives the STEP pin with a hardware timer and optional interrupts (ISD04_STEP_CONTROL_TIMER=1).
+
 ## API Reference
 
 **Core Functions:**

--- a/examples/main_gpio.c
+++ b/examples/main_gpio.c
@@ -1,0 +1,44 @@
+/**
+ * Example application toggling the STEP pin directly via GPIO.
+ *
+ * Hardware connections:
+ *   - STEP -> PA0 (GPIO output)
+ *   - DIR  -> PA1 (GPIO output)
+ *   - ENA  -> PA2 (GPIO output, active low)
+ *
+ * Build notes:
+ *   - Set ISD04_STEP_CONTROL_TIMER to 0 in isd04_driver_config.h.
+ *   - Configure the listed GPIO pins as push-pull outputs.
+ */
+
+#include "isd04_driver.h"
+
+int main(void)
+{
+    HAL_Init();
+    // GPIO initialization should configure PA0, PA1 and PA2 as outputs.
+
+    Isd04Config config;
+    isd04_driver_get_default_config(&config);
+
+    Isd04Hardware hw = {
+        .stp_port = GPIOA, .stp_pin = GPIO_PIN_0,
+        .dir_port = GPIOA, .dir_pin = GPIO_PIN_1,
+        .ena_port = GPIOA, .ena_pin = GPIO_PIN_2,
+    };
+
+    Isd04Driver *driver = isd04_driver_get_instance();
+    isd04_driver_init(driver, &config, &hw);
+
+    // Enable outputs and set initial direction
+    isd04_driver_enable(driver, true);
+    isd04_driver_set_direction(driver, true); // forward
+
+    while (1) {
+        // Generate one step pulse manually
+        isd04_driver_pulse(driver);
+        // Delay controls step frequency (adjust as needed)
+        ISD04_DELAY_US(500);
+    }
+}
+

--- a/examples/main_timer.c
+++ b/examples/main_timer.c
@@ -1,0 +1,60 @@
+/**
+ * Example application demonstrating hardware timer control of the STEP pin.
+ *
+ * Hardware connections:
+ *   - STEP -> PA0 (TIM2_CH1 configured for PWM)
+ *   - DIR  -> PA1 (GPIO output)
+ *   - ENA  -> PA2 (GPIO output, active low)
+ *
+ * Timer setup:
+ *   - TIM2 base clock set as needed for desired step frequency.
+ *   - Channel 1 configured in PWM mode 1 with 50% duty cycle.
+ *   - Update interrupt enabled if the application needs to react to each pulse.
+ *
+ * Build notes:
+ *   - Ensure ISD04_STEP_CONTROL_TIMER is set to 1 in isd04_driver_config.h.
+ *   - Provide and initialize TIM2 before running this example.
+ */
+
+#include "isd04_driver.h"
+
+// Timer handle configured elsewhere (e.g. CubeMX) for PWM output on STEP
+extern TIM_HandleTypeDef htim2;
+
+// Optional timer interrupt callback. The driver does not require it but
+// applications can hook here to monitor pulses or update motion profiles.
+void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
+{
+    if (htim == &htim2) {
+        // Timer period elapsed: place application-specific code here.
+    }
+}
+
+int main(void)
+{
+    HAL_Init();
+    // System clock and GPIO initialization should occur here.
+
+    Isd04Config config;
+    isd04_driver_get_default_config(&config);
+
+    Isd04Hardware hw = {
+        .dir_port = GPIOA, .dir_pin = GPIO_PIN_1,
+        .ena_port = GPIOA, .ena_pin = GPIO_PIN_2,
+    };
+
+    Isd04Driver *driver = isd04_driver_get_instance();
+    isd04_driver_init(driver, &config, &hw);
+    isd04_driver_bind_step_timer(driver, &htim2);
+
+    // Enable outputs and start motion at 50% of maximum speed
+    isd04_driver_enable(driver, true);
+    isd04_driver_set_direction(driver, true); // forward
+    isd04_driver_set_speed(driver, config.max_speed / 2);
+    isd04_driver_start(driver);
+
+    while (1) {
+        // Main loop can perform other tasks while timer drives the motor.
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `examples` directory with GPIO and timer-based usage demos
- document new examples in README

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68aa645ae9308323a0c1e7e5e3368e83