### PR TITLE
Disable CMSIS and HAL integration by default

### DIFF
--- a/src/isd04_driver_config.h
+++ b/src/isd04_driver_config.h
@@ -13,12 +13,12 @@
 
 /* Set to 1 when building for a CMSIS-RTOS v2 environment. */
 #ifndef ISD04_USE_CMSIS
-#define ISD04_USE_CMSIS 1
+#define ISD04_USE_CMSIS 0
 #endif
 
 /* Set to 1 when using the STM32 HAL. */
 #ifndef ISD04_USE_HAL
-#define ISD04_USE_HAL 1
+#define ISD04_USE_HAL 0
 #endif
 
 #if ISD04_USE_CMSIS  /* CMSIS-RTOS v2 environment */


### PR DESCRIPTION
## Summary
- Default CMSIS-RTOS and STM32 HAL integration macros to `0` for a host-friendly build configuration.

## Testing
- `gcc -Isrc -DISD04_STEP_CONTROL_TIMER=0 -c src/isd04_driver.c`


------
https://chatgpt.com/codex/tasks/task_e_68aa67f804fc8323832a12e5d0c765e2