### PR TITLE
Handle configurable enable level at initialization

### DIFF
--- a/DValve/DValve/Drivers/isd04-motor-driver/src/isd04_driver.c
+++ b/DValve/DValve/Drivers/isd04-motor-driver/src/isd04_driver.c
@@ -222,7 +222,10 @@ void isd04_driver_init(Isd04Driver *driver, const Isd04Config *config, const Isd
     driver->current_speed = 0;
     driver->current_position = 0;
     driver->running = false;
-    driver->enabled = true;
+    GPIO_PinState ena_level = (ISD04_ENA_ACTIVE_LEVEL == GPIO_PIN_SET)
+        ? GPIO_PIN_RESET
+        : GPIO_PIN_SET;
+    driver->enabled = (ena_level != ISD04_ENA_ACTIVE_LEVEL);
     driver->last_step_tick = 0U;
 #if ISD04_STEP_CONTROL_TIMER
     driver->step_timer = NULL;
@@ -231,7 +234,7 @@ void isd04_driver_init(Isd04Driver *driver, const Isd04Config *config, const Isd
     driver->callback_context = NULL;
     driver->microstep = config->microstep;
     ISD04_APPLY_MICROSTEP(ISD04_MICROSTEP_TO_BITS(driver->microstep));
-    if (!isd04_gpio_write_pin(driver->hw.ena_port, driver->hw.ena_pin, GPIO_PIN_SET) ||
+    if (!isd04_gpio_write_pin(driver->hw.ena_port, driver->hw.ena_pin, ena_level) ||
         !isd04_gpio_write_pin(driver->hw.dir_port, driver->hw.dir_pin, GPIO_PIN_RESET)) {
         driver->error = true;
         return;

--- a/DValve/DValve_backup/Drivers/isd04-motor-driver/src/isd04_driver.c
+++ b/DValve/DValve_backup/Drivers/isd04-motor-driver/src/isd04_driver.c
@@ -222,7 +222,10 @@ void isd04_driver_init(Isd04Driver *driver, const Isd04Config *config, const Isd
     driver->current_speed = 0;
     driver->current_position = 0;
     driver->running = false;
-    driver->enabled = true;
+    GPIO_PinState ena_level = (ISD04_ENA_ACTIVE_LEVEL == GPIO_PIN_SET)
+        ? GPIO_PIN_RESET
+        : GPIO_PIN_SET;
+    driver->enabled = (ena_level != ISD04_ENA_ACTIVE_LEVEL);
     driver->last_step_tick = 0U;
 #if ISD04_STEP_CONTROL_TIMER
     driver->step_timer = NULL;
@@ -231,7 +234,7 @@ void isd04_driver_init(Isd04Driver *driver, const Isd04Config *config, const Isd
     driver->callback_context = NULL;
     driver->microstep = config->microstep;
     ISD04_APPLY_MICROSTEP(ISD04_MICROSTEP_TO_BITS(driver->microstep));
-    if (!isd04_gpio_write_pin(driver->hw.ena_port, driver->hw.ena_pin, GPIO_PIN_SET) ||
+    if (!isd04_gpio_write_pin(driver->hw.ena_port, driver->hw.ena_pin, ena_level) ||
         !isd04_gpio_write_pin(driver->hw.dir_port, driver->hw.dir_pin, GPIO_PIN_RESET)) {
         driver->error = true;
         return;

--- a/src/isd04_driver.c
+++ b/src/isd04_driver.c
@@ -324,7 +324,10 @@ void isd04_driver_init(Isd04Driver *driver, const Isd04Config *config, const Isd
     driver->current_speed = 0;
     driver->current_position = 0;
     driver->running = false;
-    driver->enabled = true;
+    GPIO_PinState ena_level = (ISD04_ENA_ACTIVE_LEVEL == GPIO_PIN_SET)
+        ? GPIO_PIN_RESET
+        : GPIO_PIN_SET;
+    driver->enabled = (ena_level != ISD04_ENA_ACTIVE_LEVEL);
     driver->last_step_tick = 0U;
 #if ISD04_STEP_CONTROL_TIMER
     driver->step_timer = NULL;
@@ -334,7 +337,7 @@ void isd04_driver_init(Isd04Driver *driver, const Isd04Config *config, const Isd
     driver->callback_context = NULL;
     driver->microstep = config->microstep;
     ISD04_APPLY_MICROSTEP(ISD04_MICROSTEP_TO_BITS(driver->microstep));
-    if (!isd04_gpio_write_pin(driver->hw.ena_port, driver->hw.ena_pin, GPIO_PIN_SET) ||
+    if (!isd04_gpio_write_pin(driver->hw.ena_port, driver->hw.ena_pin, ena_level) ||
         !isd04_gpio_write_pin(driver->hw.dir_port, driver->hw.dir_pin, GPIO_PIN_RESET)) {
         driver->error = true;
         return;


### PR DESCRIPTION
## Summary
- respect `ISD04_ENA_ACTIVE_LEVEL` when setting the initial ENA pin level
- set `driver->enabled` based on the derived level
- mirror change in duplicated driver sources

## Testing
- `gcc -c src/isd04_driver.c -Isrc -std=c99 -DISD04_STEP_CONTROL_TIMER=0`
- `gcc -c DValve/DValve/Drivers/isd04-motor-driver/src/isd04_driver.c -I DValve/DValve/Drivers/isd04-motor-driver/src -std=c99 -DISD04_STEP_CONTROL_TIMER=0` *(fails: cmsis_os.h: No such file or directory)*
- `apt-get install -y libcmsis-dev` *(fails: Unable to locate package libcmsis-dev)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6ac01ebc8323bcc39e26c0248dda