### PR TITLE
Start ISD04 driver after RTOS scheduler

### DIFF
--- a/DValve/DValve/Core/Src/main.c
+++ b/DValve/DValve/Core/Src/main.c
@@ -148,9 +148,6 @@ int main(void)
 
     // Set speed to 50 steps/sec
     isd04_driver_set_speed(motor_driver, 50);
-    
-    // Start the motor driver - this will begin automatic stepping
-    isd04_driver_start(motor_driver);
   }
     
   //   // Now test timer PWM pulse generation - create discrete pulses


### PR DESCRIPTION
## Summary
- Ensure ISD04 motor driver starts from RTOS context by removing pre-scheduler call and relying on StartDefaultTask after `osKernelStart`

## Testing
- `cmake -S DValve/DValve -B DValve/build && cmake --build DValve/build` *(fails: ARM assembly unsupported in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6fa1d0b88323a22477fd13740435