### PR TITLE
Remove PWM configuration from ISD04 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,10 @@ for (int i = 0; i < 200; ++i) {
 }
 ```
 
-`pwm_frequency_hz` defines the baseline step rate used when running
-continuously with `isd04_driver_set_speed()` and `isd04_driver_start()`.
-`max_speed` is the largest speed value the driver accepts. The actual step
-frequency is scaled linearly:
-
-```
-step_hz = pwm_frequency_hz * |speed| / max_speed
-```
+`max_speed` is the largest step rate the driver accepts (in steps per second).
+`isd04_driver_set_speed()` specifies a signed target rate within
+`[-max_speed, max_speed]`, and the driver generates steps at this rate while
+running.
 
 ## Key Features
 

--- a/src/isd04_driver.c
+++ b/src/isd04_driver.c
@@ -164,9 +164,7 @@ static void isd04_step_task(void *argument)
     while (driver) {
         if (driver->running && driver->current_speed != 0) {
             int32_t direction = driver->current_speed > 0 ? 1 : -1;
-            uint32_t step_hz =
-                driver->config.pwm_frequency_hz * (uint32_t)abs(driver->current_speed) /
-                (uint32_t)driver->config.max_speed;
+            uint32_t step_hz = (uint32_t)abs(driver->current_speed);
             if (step_hz == 0U) {
                 osDelay(1U);
                 continue;
@@ -204,8 +202,6 @@ void isd04_driver_get_default_config(Isd04Config *config)
     if (!config) {
         return;
     }
-
-    config->pwm_frequency_hz = 20000U;
     config->max_speed = 1000;
     config->microstep = ISD04_MICROSTEP_3200;
     config->phase_current_ma = 2800U;

--- a/src/isd04_driver.h
+++ b/src/isd04_driver.h
@@ -68,9 +68,7 @@ typedef enum {
  * Static configuration for the ISD04 driver.
  */
 typedef struct {
-    /** PWM frequency in Hz. */
-    uint32_t pwm_frequency_hz;
-    /** Maximum speed value permitted. */
+    /** Maximum step rate in steps per second. */
     int32_t max_speed;
     /** Default microstepping resolution. */
     Isd04Microstep microstep;


### PR DESCRIPTION
## Summary
- Drop `pwm_frequency_hz` from driver configuration and docs
- Compute step frequency directly from commanded speed
- Update README to describe speed in steps per second

## Testing
- `gcc -std=c99 -Isrc -c src/isd04_driver.c`
- `gcc -std=c99 -Isrc src/isd04_driver.c examples/main_gpio.c -o example` *(fails: GPIOA/GPIO_PIN_* undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7d0b5cc4832383afff6cdede0da6