### PR TITLE
Interpret motor speed as RPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ for (int i = 0; i < 200; ++i) {
 }
 ```
 
-`max_speed` is the largest step rate the driver accepts (in steps per second).
-`isd04_driver_set_speed()` specifies a signed target rate within
-`[-max_speed, max_speed]`, and the driver generates steps at this rate while
-running.
+`max_speed` is the largest motor speed the driver accepts (in revolutions per
+minute, RPM). `isd04_driver_set_speed()` specifies a signed target speed within
+`[-max_speed, max_speed]`, and the driver generates step pulses at the
+corresponding rate while running.
 
 ### CMSIS-RTOS task
 
 When `ISD04_USE_CMSIS` is enabled the driver can generate step pulses from a
 background thread. Call `isd04_driver_start()` once the RTOS is running to
-launch the internal task and use `isd04_driver_set_speed()` to update the step
-rate while the motor is running. `isd04_driver_stop()` halts the task.
+launch the internal task and use `isd04_driver_set_speed()` to update the motor
+speed while it is running. `isd04_driver_stop()` halts the task.
 
 ```c
 #include "cmsis_os2.h"
@@ -58,10 +58,10 @@ static void motor_task(void *argument) {
     Isd04Driver *driver = argument;
 
     isd04_driver_start(driver);            // start internal step thread
-    isd04_driver_set_speed(driver, 100);   // run forward
+    isd04_driver_set_speed(driver, 100);   // run forward at 100 RPM
     osDelay(1000);
 
-    isd04_driver_set_speed(driver, -100);  // reverse direction
+    isd04_driver_set_speed(driver, -100);  // reverse direction at 100 RPM
     osDelay(1000);
 
     isd04_driver_stop(driver);             // stop motor

--- a/examples/main_cmsis.c
+++ b/examples/main_cmsis.c
@@ -24,12 +24,12 @@ static void motor_task(void *argument)
     /* Start background step generation */
     isd04_driver_start(driver);
 
-    /* Run forward at 100 steps/s for 1 second */
+    /* Run forward at 100 RPM for 1 second */
     isd04_driver_set_direction(driver, true);
     isd04_driver_set_speed(driver, 100);
     osDelay(1000);
 
-    /* Reverse and slow down */
+    /* Reverse and slow down to 50 RPM */
     isd04_driver_set_direction(driver, false);
     isd04_driver_set_speed(driver, 50);
     osDelay(1000);

--- a/src/isd04_driver.c
+++ b/src/isd04_driver.c
@@ -164,7 +164,8 @@ static void isd04_step_task(void *argument)
     while (driver) {
         if (driver->running && driver->current_speed != 0) {
             int32_t direction = driver->current_speed > 0 ? 1 : -1;
-            uint32_t step_hz = (uint32_t)abs(driver->current_speed);
+            uint32_t step_hz = (uint32_t)(abs(driver->current_speed) *
+                                         (int32_t)driver->microstep / 60);
             if (step_hz == 0U) {
                 osDelay(1U);
                 continue;

--- a/src/isd04_driver.h
+++ b/src/isd04_driver.h
@@ -68,7 +68,7 @@ typedef enum {
  * Static configuration for the ISD04 driver.
  */
 typedef struct {
-    /** Maximum step rate in steps per second. */
+    /** Maximum motor speed in RPM. */
     int32_t max_speed;
     /** Default microstepping resolution. */
     Isd04Microstep microstep;
@@ -160,7 +160,7 @@ typedef struct {
     Isd04Config config;
     /** Hardware pins controlling the driver. */
     Isd04Hardware hw;
-    /** Current motor speed. */
+    /** Current motor speed in RPM. */
     int32_t current_speed;
     /** Current motor position in steps. */
     int32_t current_position;
@@ -240,12 +240,12 @@ void isd04_driver_stop(Isd04Driver *driver);
  * ::ISD04_EVENT_SPEED_CHANGED when the speed actually changes.
  *
  * @param driver Driver instance.
- * @param speed  New speed in steps per second.
+ * @param speed  New speed in RPM.
  */
 void isd04_driver_set_speed(Isd04Driver *driver, int32_t speed);
 
 /**
- * Obtain the current motor speed in steps per second.
+ * Obtain the current motor speed in RPM.
  *
  * @param driver Driver instance.
  * @return Current speed value; 0 if @p driver is NULL.


### PR DESCRIPTION
## Summary
- Convert runtime speed to step frequency using motor microstep resolution, allowing speed values in RPM
- Document speed units as RPM throughout the public API and examples

## Testing
- `gcc -std=c99 -c src/isd04_driver.c -I src -DISD04_USE_CMSIS=0 -DISD04_USE_HAL=0`
- `gcc -std=c99 -c examples/main_cmsis.c -I src -DISD04_USE_CMSIS=0 -DISD04_USE_HAL=0` *(fails: cmsis_os2.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8641ac108323952e799e3268dad0